### PR TITLE
Fix typos and add initial tests

### DIFF
--- a/schoolbotplugin.pas
+++ b/schoolbotplugin.pas
@@ -90,7 +90,7 @@ type
     function CreateInKbEditUser(aUserID: Int64): TInlineKeyboard;
     function CreateInKbOpenDialog(aSessionID: Integer): TInlineKeyboard;
     function CreateReplyKeyboardStart: TReplyMarkup;
-    function CreateReplyKeyboardDialogSession: TKeybordButtonArray;
+    function CreateReplyKeyboardDialogSession: TKeyboardButtonArray;
     procedure DataFieldSet(aEntityType: TEntityType; aID: Int64; const aField: String;
       const aValue: String; aMessage: TTelegramMessageObj);
     procedure DataFieldSet(const aData: String; aMessage: TTelegramMessageObj);
@@ -242,7 +242,7 @@ resourcestring
   s_NewCourse='New course';
   s_MyCourses='My courses';
   s_Back='Back';
-  s_ConfLang='Interface Language';    // Выбрать язык бота';
+  s_ConfLang='Interface Language';    // Выбрать язык бота
   s_SettingsText='Here you can customize';   //Здесь Вы можете настроить словари под себя.'+LineEnding+LineEnding+
   s_SettingsLang='Interface Language:'; //Выберите язык бота:';
   s_StartText='Start text';
@@ -2009,7 +2009,7 @@ var
 begin
   Result:=TReplyMarkup.Create;
   Result.ResizeKeyboard:=True;
-  Result.ReplyKeyboardMarkup:=TKeybordButtonArray.Create;
+  Result.ReplyKeyboardMarkup:=TKeyboardButtonArray.Create;
   if AllCanCreateCourse or not Bot.CurrentIsSimpleUser then
     aMenuItem:=s_CourseCreation
   else
@@ -2021,9 +2021,9 @@ begin
   Result.ReplyKeyboardMarkup.Add.AddButtons([s_Help, s_Storage, s_Settings]);
 end;
 
-function TSchoolBotPlugin.CreateReplyKeyboardDialogSession: TKeybordButtonArray;
+function TSchoolBotPlugin.CreateReplyKeyboardDialogSession: TKeyboardButtonArray;
 begin
-  Result:=TKeybordButtonArray.Create;
+  Result:=TKeyboardButtonArray.Create;
   Result.Add.AddButtons([s_DialogExit]);
 end;
 
@@ -2132,7 +2132,6 @@ function TSchoolBotPlugin.CheckChannelMember(aChat: Int64; aUser: Int64
 var
   aChatMember: TTelegramChatMember;
 begin
-  Exit(True);
   Bot.getChatMember(aChat, aUser, aChatMember);
   Result:=aChatMember.is_member;
   if not Result then

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+fpc test_utils.pas && ./test_utils

--- a/tests/test_utils.pas
+++ b/tests/test_utils.pas
@@ -1,0 +1,31 @@
+program test_utils;
+
+{$mode objfpc}{$H+}
+
+uses
+  fpcunit, testutils, testregistry, schoolbotplugin;
+
+type
+  TUtilsTest = class(TTestCase)
+  published
+    procedure TestGetDataFromLine;
+    procedure TestCaptionFromLangCode;
+  end;
+
+procedure TUtilsTest.TestGetDataFromLine;
+begin
+  AssertEquals('param1 param2', GetDataFromLine('cmd param1 param2'));
+  AssertEquals('', GetDataFromLine('single'));
+end;
+
+procedure TUtilsTest.TestCaptionFromLangCode;
+begin
+  AssertEquals(lng_English, CaptionFromLangCode('en'));
+  AssertEquals(lng_Russian, CaptionFromLangCode('ru'));
+  AssertEquals('', CaptionFromLangCode('unknown'));
+end;
+
+begin
+  RegisterTest(TUtilsTest);
+  RunRegisteredTests;
+end.


### PR DESCRIPTION
## Summary
- rename `TKeybordButtonArray` to `TKeyboardButtonArray`
- remove early `Exit(True)` in `CheckChannelMember`
- fix Russian comment for `s_ConfLang`
- add simple FPCUnit test program for utility functions

## Testing
- `cd tests && ./run_tests.sh` *(fails: Can't find unit schoolbotplugin)*

------
https://chatgpt.com/codex/tasks/task_e_685185bd76fc8328a546769ec37fd69c